### PR TITLE
feat(api): add guidal.org integration endpoint

### DIFF
--- a/supabase/functions/tradesmen/index.ts
+++ b/supabase/functions/tradesmen/index.ts
@@ -31,6 +31,10 @@ Deno.serve(async (req) => {
   // Auth
   const apiKey = req.headers.get("x-api-key");
   const expectedKey = Deno.env.get("GUIDAL_API_KEY");
+  if (!expectedKey) {
+    console.error("[tradesmen] GUIDAL_API_KEY secret is not set");
+    return jsonResponse({ error: "Service misconfigured" }, 503);
+  }
   if (!apiKey || apiKey !== expectedKey) {
     return jsonResponse({ error: "Unauthorized" }, 401);
   }
@@ -68,6 +72,14 @@ Deno.serve(async (req) => {
   if (isNaN(page) || page < 1) {
     return jsonResponse(
       { error: "Invalid parameter", details: "page must be an integer >= 1" },
+      400,
+    );
+  }
+
+  // Validate location length
+  if (location && location.length > 100) {
+    return jsonResponse(
+      { error: "Invalid parameter", details: "location must be <= 100 characters" },
       400,
     );
   }
@@ -125,7 +137,8 @@ Deno.serve(async (req) => {
         total: countResult.count ?? 0,
       },
     });
-  } catch (_err) {
+  } catch (err) {
+    console.error("[tradesmen] unhandled error:", err);
     return jsonResponse({ error: "Internal server error" }, 500);
   }
 });

--- a/supabase/functions/tradesmen/index.ts
+++ b/supabase/functions/tradesmen/index.ts
@@ -1,0 +1,131 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const VALID_CATEGORIES = [
+  "electrician", "plumber", "carpenter", "painter", "general_handyman",
+  "locksmith", "gardener", "cleaner", "mason", "roofer", "hvac", "other",
+] as const;
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "x-api-key",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  if (req.method !== "GET") {
+    return jsonResponse({ error: "Method not allowed" }, 405);
+  }
+
+  // Auth
+  const apiKey = req.headers.get("x-api-key");
+  const expectedKey = Deno.env.get("GUIDAL_API_KEY");
+  if (!apiKey || apiKey !== expectedKey) {
+    return jsonResponse({ error: "Unauthorized" }, 401);
+  }
+
+  // Parse query params
+  const url = new URL(req.url);
+  const category = url.searchParams.get("category");
+  const location = url.searchParams.get("location");
+  const availableParam = url.searchParams.get("available");
+  const pageParam = url.searchParams.get("page");
+  const limitParam = url.searchParams.get("limit");
+
+  // Validate category
+  if (category && !VALID_CATEGORIES.includes(category as typeof VALID_CATEGORIES[number])) {
+    return jsonResponse(
+      { error: "Invalid parameter", details: `category must be one of: ${VALID_CATEGORIES.join(", ")}` },
+      400,
+    );
+  }
+
+  // Validate available
+  let available: boolean | null = null;
+  if (availableParam !== null) {
+    if (availableParam !== "true" && availableParam !== "false") {
+      return jsonResponse(
+        { error: "Invalid parameter", details: "available must be true or false" },
+        400,
+      );
+    }
+    available = availableParam === "true";
+  }
+
+  // Validate page
+  const page = pageParam ? parseInt(pageParam, 10) : 1;
+  if (isNaN(page) || page < 1) {
+    return jsonResponse(
+      { error: "Invalid parameter", details: "page must be an integer >= 1" },
+      400,
+    );
+  }
+
+  // Validate limit
+  const limit = limitParam ? parseInt(limitParam, 10) : 20;
+  if (isNaN(limit) || limit < 1 || limit > 100) {
+    return jsonResponse(
+      { error: "Invalid parameter", details: "limit must be 1-100" },
+      400,
+    );
+  }
+
+  try {
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL")!,
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+    );
+
+    // Build query with filters
+    let countQuery = supabase
+      .from("tradesmen_public")
+      .select("*", { count: "exact", head: true });
+
+    let dataQuery = supabase
+      .from("tradesmen_public")
+      .select("*")
+      .order("is_featured", { ascending: false })
+      .order("avg_rating", { ascending: false })
+      .range((page - 1) * limit, page * limit - 1);
+
+    if (category) {
+      countQuery = countQuery.eq("trade_category", category);
+      dataQuery = dataQuery.eq("trade_category", category);
+    }
+    if (location) {
+      countQuery = countQuery.ilike("location", `%${location}%`);
+      dataQuery = dataQuery.ilike("location", `%${location}%`);
+    }
+    if (available !== null) {
+      countQuery = countQuery.eq("is_available", available);
+      dataQuery = dataQuery.eq("is_available", available);
+    }
+
+    const [countResult, dataResult] = await Promise.all([countQuery, dataQuery]);
+
+    if (countResult.error) throw countResult.error;
+    if (dataResult.error) throw dataResult.error;
+
+    return jsonResponse({
+      data: dataResult.data,
+      pagination: {
+        page,
+        limit,
+        total: countResult.count ?? 0,
+      },
+    });
+  } catch (_err) {
+    return jsonResponse({ error: "Internal server error" }, 500);
+  }
+});

--- a/supabase/functions/tradesmen/index.ts
+++ b/supabase/functions/tradesmen/index.ts
@@ -99,42 +99,27 @@ Deno.serve(async (req) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
     );
 
-    // Build query with filters
-    let countQuery = supabase
+    // Build query — select with count returns both data and total in one request
+    let query = supabase
       .from("tradesmen_public")
-      .select("*", { count: "exact", head: true });
-
-    let dataQuery = supabase
-      .from("tradesmen_public")
-      .select("*")
+      .select("*", { count: "exact" })
       .order("is_featured", { ascending: false })
       .order("avg_rating", { ascending: false })
       .range((page - 1) * limit, page * limit - 1);
 
-    if (category) {
-      countQuery = countQuery.eq("trade_category", category);
-      dataQuery = dataQuery.eq("trade_category", category);
-    }
-    if (location) {
-      countQuery = countQuery.ilike("location", `%${location}%`);
-      dataQuery = dataQuery.ilike("location", `%${location}%`);
-    }
-    if (available !== null) {
-      countQuery = countQuery.eq("is_available", available);
-      dataQuery = dataQuery.eq("is_available", available);
-    }
+    if (category) query = query.eq("trade_category", category);
+    if (location) query = query.ilike("location", `%${location}%`);
+    if (available !== null) query = query.eq("is_available", available);
 
-    const [countResult, dataResult] = await Promise.all([countQuery, dataQuery]);
-
-    if (countResult.error) throw countResult.error;
-    if (dataResult.error) throw dataResult.error;
+    const { data, count, error } = await query;
+    if (error) throw error;
 
     return jsonResponse({
-      data: dataResult.data,
+      data,
       pagination: {
         page,
         limit,
-        total: countResult.count ?? 0,
+        total: count ?? 0,
       },
     });
   } catch (err) {

--- a/supabase/functions/tradesmen/openapi.yaml
+++ b/supabase/functions/tradesmen/openapi.yaml
@@ -1,0 +1,224 @@
+openapi: 3.1.0
+info:
+  title: ConfiaMaresme Tradesmen API
+  description: Public API for pulling tradesman directory data from ConfiaMaresme.
+  version: 1.0.0
+  contact:
+    name: ConfiaMaresme
+    url: https://confiamaresme.com
+
+servers:
+  - url: https://ihhdazltdyctyygxcblw.supabase.co/functions/v1
+    description: Production
+
+security:
+  - apiKey: []
+
+paths:
+  /tradesmen:
+    get:
+      summary: List tradesmen
+      description: Returns a paginated list of tradesmen with aggregate review ratings. Results are sorted by featured status first, then by average rating descending.
+      operationId: listTradesmen
+      parameters:
+        - name: category
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/TradeCategory"
+        - name: location
+          in: query
+          description: Case-insensitive substring match against tradesman location.
+          required: false
+          schema:
+            type: string
+            maxLength: 100
+            example: alella
+        - name: available
+          in: query
+          description: Filter by availability.
+          required: false
+          schema:
+            type: boolean
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        "200":
+          description: Paginated list of tradesmen.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, pagination]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Tradesman"
+                  pagination:
+                    $ref: "#/components/schemas/Pagination"
+        "400":
+          description: Invalid query parameter.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+        "401":
+          description: Missing or invalid API key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "405":
+          description: Method not allowed (only GET is accepted).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "503":
+          description: Service misconfigured.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: x-api-key
+
+  schemas:
+    TradeCategory:
+      type: string
+      enum:
+        - electrician
+        - plumber
+        - carpenter
+        - painter
+        - general_handyman
+        - locksmith
+        - gardener
+        - cleaner
+        - mason
+        - roofer
+        - hvac
+        - other
+
+    Tradesman:
+      type: object
+      required:
+        - id
+        - full_name
+        - trade_category
+        - is_available
+        - vetted_by_community
+        - is_featured
+        - subscription_tier
+        - avg_rating
+        - review_count
+      properties:
+        id:
+          type: string
+          format: uuid
+        full_name:
+          type: string
+          example: Carlos Garcia Lopez
+        trade_category:
+          $ref: "#/components/schemas/TradeCategory"
+        additional_categories:
+          type: array
+          items:
+            type: string
+          example: ["general_handyman"]
+        bio:
+          type: string
+          nullable: true
+        location:
+          type: string
+          nullable: true
+          example: "Mataro, Maresme"
+        whatsapp_number:
+          type: string
+          nullable: true
+          example: "+34612345678"
+        profile_image_url:
+          type: string
+          format: uri
+          nullable: true
+        is_available:
+          type: boolean
+        vetted_by_community:
+          type: boolean
+        services:
+          type: array
+          items:
+            type: string
+          nullable: true
+          example: ["Instalaciones", "Reparaciones"]
+        languages:
+          type: array
+          items:
+            type: string
+          example: ["es", "ca"]
+        is_featured:
+          type: boolean
+        subscription_tier:
+          type: string
+          example: free
+        avg_rating:
+          type: number
+          minimum: 0
+          maximum: 5
+          example: 4.3
+        review_count:
+          type: integer
+          minimum: 0
+          example: 7
+
+    Pagination:
+      type: object
+      required: [page, limit, total]
+      properties:
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 20
+        total:
+          type: integer
+          example: 142
+
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+          example: Unauthorized
+
+    ValidationError:
+      type: object
+      required: [error, details]
+      properties:
+        error:
+          type: string
+          example: Invalid parameter
+        details:
+          type: string
+          example: "limit must be 1-100"

--- a/supabase/migrations/20260401140000_create_tradesmen_public_view.sql
+++ b/supabase/migrations/20260401140000_create_tradesmen_public_view.sql
@@ -1,0 +1,27 @@
+CREATE VIEW public.tradesmen_public AS
+SELECT
+  t.id,
+  t.full_name,
+  t.trade_category,
+  t.additional_categories,
+  t.bio,
+  t.location,
+  t.whatsapp_number,
+  t.profile_image_url,
+  t.is_available,
+  t.vetted_by_community,
+  t.services,
+  t.languages,
+  t.is_featured,
+  t.subscription_tier,
+  COALESCE(r.avg_rating, 0) AS avg_rating,
+  COALESCE(r.review_count, 0) AS review_count
+FROM public.tradesmen t
+LEFT JOIN (
+  SELECT
+    tradesman_id,
+    ROUND(AVG(rating)::numeric, 1) AS avg_rating,
+    COUNT(*)::integer AS review_count
+  FROM public.reviews
+  GROUP BY tradesman_id
+) r ON r.tradesman_id = t.id;

--- a/supabase/migrations/20260401140000_create_tradesmen_public_view.sql
+++ b/supabase/migrations/20260401140000_create_tradesmen_public_view.sql
@@ -1,4 +1,4 @@
-CREATE VIEW public.tradesmen_public AS
+CREATE OR REPLACE VIEW public.tradesmen_public AS
 SELECT
   t.id,
   t.full_name,
@@ -25,3 +25,5 @@ LEFT JOIN (
   FROM public.reviews
   GROUP BY tradesman_id
 ) r ON r.tradesman_id = t.id;
+
+GRANT SELECT ON public.tradesmen_public TO anon, authenticated;

--- a/supabase/migrations/20260401140000_create_tradesmen_public_view.sql
+++ b/supabase/migrations/20260401140000_create_tradesmen_public_view.sql
@@ -27,3 +27,10 @@ LEFT JOIN (
 ) r ON r.tradesman_id = t.id;
 
 GRANT SELECT ON public.tradesmen_public TO anon, authenticated;
+
+-- Indexes for Edge Function filter/sort queries
+CREATE INDEX IF NOT EXISTS idx_tradesmen_category_featured
+  ON public.tradesmen (trade_category, is_featured DESC);
+
+CREATE INDEX IF NOT EXISTS idx_tradesmen_available
+  ON public.tradesmen (is_available) WHERE is_available = true;


### PR DESCRIPTION
## Summary

Adds a public API for guidal.org to pull tradesman directory data from ConfiaMaresme.

**Ticket:** N/A

### Problem addressed

Martin (guidal.org) needs tradesman data for his jobs directory. No external API exists — the data lives only in Supabase behind the React frontend.

### Solution applied

A Supabase Edge Function exposes `tradesmen_public` view data over HTTP with API-key authentication. Martin calls one endpoint, gets paginated JSON, renders it however he wants.

## Changes

- **Postgres view** (`tradesmen_public`): joins `tradesmen` with aggregated review ratings, excludes internal fields (`user_id`, `is_claimed`, `view_count`)
- **Edge Function** (`supabase/functions/tradesmen/index.ts`): validates API key, filters by category/location/availability, returns paginated JSON sorted by featured status then rating

## Deployment (manual, post-merge)

1. `supabase db push` — applies the view migration
2. `supabase secrets set GUIDAL_API_KEY=<key>` — sets the API key
3. `supabase functions deploy tradesmen --no-verify-jwt` — deploys the function
4. Send Martin the key and endpoint docs

## AI Assistance

**Session ID:** `4b0069bc-b22a-4897-98cc-015e5eaa8a52`