### PR TITLE
fix(api): return empty page on out-of-bounds pagination

### DIFF
--- a/supabase/functions/tradesmen/index.ts
+++ b/supabase/functions/tradesmen/index.ts
@@ -112,7 +112,16 @@ Deno.serve(async (req) => {
     if (available !== null) query = query.eq("is_available", available);
 
     const { data, count, error } = await query;
-    if (error) throw error;
+    if (error) {
+      // Supabase returns a range error when offset exceeds row count — return empty page
+      if (error.code === "PGRST103") {
+        return jsonResponse({
+          data: [],
+          pagination: { page, limit, total: count ?? 0 },
+        });
+      }
+      throw error;
+    }
 
     return jsonResponse({
       data,


### PR DESCRIPTION
## Summary

Fixes a 500 Internal Server Error when requesting pages beyond the result set.

**Ticket:** N/A

### Problem addressed

Supabase's `.range()` returns a `PGRST103` error when the offset exceeds the total row count. Any page past the last valid page (e.g., `?page=3` with 34 tradesmen at `limit=20`) returned a 500 instead of an empty result.

### Solution applied

Catch the `PGRST103` range error and return an empty data array with the correct total count, matching the standard pagination contract.

## Testing

Found by Schemathesis fuzzing against the OpenAPI spec:
```
GET /tradesmen?page=10141&location=alella&category=locksmith → 500
```

After fix, same request returns:
```json
{"data": [], "pagination": {"page": 10141, "limit": 20, "total": 34}}
```

## AI Assistance

**Session ID:** `20e9f998-f35d-496d-b4c6-8f57113da063`