### PR TITLE
ci: add Edge Function deploy pipeline with lineage tracking

### DIFF
--- a/.github/workflows/deploy-edge-functions.yml
+++ b/.github/workflows/deploy-edge-functions.yml
@@ -1,0 +1,122 @@
+name: Deploy Edge Functions
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "supabase/functions/**"
+      - "supabase/migrations/**"
+
+  workflow_dispatch:
+    inputs:
+      function:
+        description: "Function to deploy (blank = all changed)"
+        required: false
+
+permissions:
+  contents: write
+  deployments: write
+
+env:
+  SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+  SUPABASE_PROJECT_REF: ihhdazltdyctyygxcblw
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      functions: ${{ steps.changed.outputs.functions }}
+      migrations: ${{ steps.changed.outputs.migrations }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect changed functions and migrations
+        id: changed
+        run: |
+          if [ -n "${{ inputs.function }}" ]; then
+            echo "functions=[\"${{ inputs.function }}\"]" >> "$GITHUB_OUTPUT"
+            echo "migrations=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Find changed function directories
+          FUNCTIONS=$(git diff --name-only HEAD~1 -- supabase/functions/ \
+            | cut -d/ -f3 | sort -u | jq -R -s -c 'split("\n") | map(select(. != ""))')
+          echo "functions=${FUNCTIONS}" >> "$GITHUB_OUTPUT"
+
+          # Check for migration changes
+          if git diff --name-only HEAD~1 -- supabase/migrations/ | grep -q .; then
+            echo "migrations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "migrations=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy-migrations:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.migrations == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Push migrations
+        run: supabase db push
+
+  deploy-functions:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, deploy-migrations]
+    if: always() && needs.detect-changes.outputs.functions != '[]'
+    strategy:
+      matrix:
+        function: ${{ fromJson(needs.detect-changes.outputs.functions) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+
+      - name: Link project
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Deploy ${{ matrix.function }}
+        run: supabase functions deploy "${{ matrix.function }}" --no-verify-jwt
+
+      - name: Tag deployment
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          TAG="deploy/${{ matrix.function }}/$(date -u +%Y%m%d-%H%M)-${SHA}"
+          git tag -a "${TAG}" -m "Deploy ${{ matrix.function }} from ${SHA}"
+          git push origin "${TAG}"
+
+      - name: Create GitHub deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: production
+          description: "Deploy ${{ matrix.function }} from ${{ github.sha }}"
+          ref: ${{ github.sha }}
+
+  smoke-test:
+    runs-on: ubuntu-latest
+    needs: deploy-functions
+    if: always() && needs.deploy-functions.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Newman
+        run: npm install -g newman
+
+      - name: Run smoke tests
+        run: |
+          if [ -f tests/postman/tradesmen.postman_collection.json ]; then
+            newman run tests/postman/tradesmen.postman_collection.json
+          else
+            echo "No smoke test collection found, skipping"
+          fi
+        env:
+          GUIDAL_API_KEY: ${{ secrets.GUIDAL_API_KEY }}

--- a/scripts/deploy-function.sh
+++ b/scripts/deploy-function.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy a Supabase Edge Function with lineage tracking.
+#
+# Usage:
+#   ./scripts/deploy-function.sh <function-name>
+#
+# What it does:
+#   1. Deploys the function via supabase CLI
+#   2. Tags the commit: deploy/<function>/<date>-<sha>
+#   3. Creates a GitHub Deployment record linked to the commit
+#
+# Prerequisites: supabase CLI (linked), gh CLI (authenticated), git
+
+FUNCTION="${1:?Usage: deploy-function.sh <function-name>}"
+SHA=$(git rev-parse --short HEAD)
+FULL_SHA=$(git rev-parse HEAD)
+DATE=$(date -u +%Y%m%d-%H%M)
+TAG="deploy/${FUNCTION}/${DATE}-${SHA}"
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+echo "==> Deploying function: ${FUNCTION}"
+echo "    Commit: ${SHA}"
+echo "    Tag:    ${TAG}"
+echo ""
+
+# 1. Deploy
+supabase functions deploy "${FUNCTION}" --no-verify-jwt
+
+# 2. Tag
+git tag -a "${TAG}" -m "Deploy ${FUNCTION} from ${SHA}"
+git push origin "${TAG}"
+
+# 3. GitHub Deployment record
+DEPLOY_ID=$(gh api "repos/${REPO}/deployments" \
+  -f ref="${FULL_SHA}" \
+  -f environment="production" \
+  -f task="deploy" \
+  -f auto_merge=false \
+  -f required_contexts="[]" \
+  -f description="Deploy ${FUNCTION} from ${SHA}" \
+  --jq '.id')
+
+gh api "repos/${REPO}/deployments/${DEPLOY_ID}/statuses" \
+  -f state="success" \
+  -f description="Deployed ${FUNCTION}" \
+  -f environment="production" \
+  > /dev/null
+
+echo ""
+echo "==> Deployed successfully"
+echo "    Function:   ${FUNCTION}"
+echo "    Commit:     ${SHA}"
+echo "    Tag:        ${TAG}"
+echo "    Deployment: https://github.com/${REPO}/deployments/activity_log?environment=production"


### PR DESCRIPTION
## Summary

Adds automated CI/CD for Supabase Edge Function deployments with full commit-to-deploy traceability.

**Ticket:** N/A

### Problem addressed

Deployments were manual CLI commands with no record of which commit was deployed when. No lineage between PRs, commits, and production state.

### Solution applied

A GitHub Actions workflow that triggers on push to main when `supabase/functions/**` or `supabase/migrations/**` change. Each deploy creates a git tag and a GitHub Deployment record.

## Changes

- `.github/workflows/deploy-edge-functions.yml` — 4-job pipeline: detect-changes → deploy-migrations → deploy-functions → smoke-test
- `scripts/deploy-function.sh` — local fallback with same lineage tracking

### Pipeline details

| Job | Trigger | What it does |
|-----|---------|-------------|
| detect-changes | Always | Finds which functions/migrations changed |
| deploy-migrations | Migrations changed | `supabase db push` |
| deploy-functions | Functions changed | Deploy + git tag + GitHub Deployment record |
| smoke-test | After deploy | Runs Newman collection if present |

### Required secrets

- `SUPABASE_ACCESS_TOKEN` — Supabase CLI auth
- `GUIDAL_API_KEY` — for smoke test Newman collection

## AI Assistance

**Session ID:** `20e9f998-f35d-496d-b4c6-8f57113da063`